### PR TITLE
Fix Item Types Not Matching

### DIFF
--- a/src/IdentifierExtractor.php
+++ b/src/IdentifierExtractor.php
@@ -54,7 +54,7 @@ class IdentifierExtractor
             }
 
             if (in_array($item->getType(), $this->extractStatements)) {
-                $globals[] = $item->name->name;
+                $globals[] = $item->name;
             }
         }
 

--- a/src/IdentifierExtractor.php
+++ b/src/IdentifierExtractor.php
@@ -10,10 +10,10 @@ class IdentifierExtractor
     {
         $this->stubFiles = [];
         $this->extractStatements = $statements ?? [
-            "PhpParser\Node\Stmt\Class_",
-            "PhpParser\Node\Stmt\Interface_",
-            "PhpParser\Node\Stmt\Trait_",
-            "PhpParser\Node\Stmt\Function_"
+            "Stmt_Class",
+            "Stmt_Interface",
+            "Stmt_Trait",
+            "Stmt_Function"
         ];
     }
 
@@ -53,7 +53,7 @@ class IdentifierExtractor
                 $items = array_merge($items, $item->stmts);
             }
 
-            if (in_array(get_class($item), $this->extractStatements)) {
+            if (in_array($item->getType(), $this->extractStatements)) {
                 $globals[] = $item->name->name;
             }
         }


### PR DESCRIPTION
Switching from AST node's class type to the _node type_ allows more flexible matching. If the class names of the node instances change, as is the scenario with PHPScoper because it itself is scoped, the node type remains the same and allows the matching to continue working.