### PR TITLE
Separate Symbols

### DIFF
--- a/src/CompositeIdentifiers.php
+++ b/src/CompositeIdentifiers.php
@@ -2,6 +2,9 @@
 
 namespace pxlrbt\PhpScoper\PrefixRemover;
 
+/**
+ * An identifier collection that aggregates identifiers from multiple other collections.
+ */
 class CompositeIdentifiers implements IdentifiersInterface
 {
     /**
@@ -13,30 +16,44 @@ class CompositeIdentifiers implements IdentifiersInterface
     protected $constants;
     protected $all;
 
-
+    /**
+     * @param iterable<IdentifiersInterface> $identifiersList
+     */
     public function __construct(iterable $identifiersList)
     {
         $this->identifiersList = $identifiersList;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getFunctions(): iterable
     {
         $this->_ensureIndex();
         return $this->functions;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getClasses(): iterable
     {
         $this->_ensureIndex();
         return $this->classes;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getConstants(): iterable
     {
         $this->_ensureIndex();
         return $this->constants;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getAll(): iterable
     {
         yield from $this->getFunctions();
@@ -44,12 +61,16 @@ class CompositeIdentifiers implements IdentifiersInterface
         yield from $this->getConstants();
     }
 
+    /**
+     * Merges symbols from all internal identifier collections, and caches them.
+     *
+     * The symbols are accessible via the `$functions`, `$classes`, and `$constants` properties afterwards.
+     */
     protected function _ensureIndex()
     {
         if (is_iterable($this->functions) && is_iterable($this->classes) && is_iterable($this->all)) {
             return;
         }
-
 
         foreach ($this->identifiersList as $identifiers) {
             /* @var $identifiers IdentifiersInterface */
@@ -60,6 +81,8 @@ class CompositeIdentifiers implements IdentifiersInterface
     }
 
     /**
+     * Appends a list to the end of another list.
+     *
      * @param iterable $toList A list to append to.
      * @param iterable $sourceList A list to append.
      *

--- a/src/CompositeIdentifiers.php
+++ b/src/CompositeIdentifiers.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace pxlrbt\PhpScoper\PrefixRemover;
+
+class CompositeIdentifiers implements IdentifiersInterface
+{
+    /**
+     * @var iterable<IdentifiersInterface>
+     */
+    protected $identifiersList;
+    protected $functions;
+    protected $classes;
+    protected $constants;
+    protected $all;
+
+
+    public function __construct(iterable $identifiersList)
+    {
+        $this->identifiersList = $identifiersList;
+    }
+
+    public function getFunctions(): iterable
+    {
+        $this->_ensureIndex();
+        return $this->functions;
+    }
+
+    public function getClasses(): iterable
+    {
+        $this->_ensureIndex();
+        return $this->classes;
+    }
+
+    public function getConstants(): iterable
+    {
+        $this->_ensureIndex();
+        return $this->constants;
+    }
+
+    public function getAll(): iterable
+    {
+        yield from $this->getFunctions();
+        yield from $this->getClasses();
+        yield from $this->getConstants();
+    }
+
+    protected function _ensureIndex()
+    {
+        if (is_iterable($this->functions) && is_iterable($this->classes) && is_iterable($this->all)) {
+            return;
+        }
+
+
+        foreach ($this->identifiersList as $identifiers) {
+            /* @var $identifiers IdentifiersInterface */
+            $this->functions = $this->appendList($this->functions, $identifiers->getFunctions());
+            $this->classes = $this->appendList($this->classes, $identifiers->getClasses());
+            $this->constants = $this->appendList($this->constants, $identifiers->getConstants());
+        }
+    }
+
+    /**
+     * @param iterable $toList A list to append to.
+     * @param iterable $sourceList A list to append.
+     *
+     * @return iterable<iterable> A list with all items from the given lists. Duplicates possible.
+     */
+    protected function appendList(iterable $toList, iterable $sourceList): iterable
+    {
+        yield from $toList;
+        yield from $sourceList;
+    }
+}

--- a/src/CompositeIdentifiers.php
+++ b/src/CompositeIdentifiers.php
@@ -7,13 +7,15 @@ namespace pxlrbt\PhpScoper\PrefixRemover;
  */
 class CompositeIdentifiers implements IdentifiersInterface
 {
-    /**
-     * @var iterable<IdentifiersInterface>
-     */
+    /** @var iterable<IdentifiersInterface> */
     protected $identifiersList;
+    /** @var iterable<string>|null */
     protected $functions;
+    /** @var iterable<string>|null */
     protected $classes;
+    /** @var iterable<string>|null */
     protected $constants;
+    /** @var iterable<string>|null */
     protected $all;
 
     /**

--- a/src/Identifiers.php
+++ b/src/Identifiers.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace pxlrbt\PhpScoper\PrefixRemover;
+
+/**
+ * A collection of PHP identifiers of different types.
+ */
+class Identifiers implements IdentifiersInterface
+{
+    protected $functions;
+    protected $classes;
+    protected $constants;
+
+    public function __construct(
+        iterable $functions,
+        iterable $classes,
+        iterable $constants
+    )
+    {
+        $this->functions = $functions;
+        $this->classes = $classes;
+        $this->constants = $constants;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFunctions(): iterable
+    {
+        return $this->functions;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getClasses(): iterable
+    {
+        return $this->classes;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConstants(): iterable
+    {
+        return $this->constants;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAll(): iterable
+    {
+        yield from $this->getFunctions();
+        yield from $this->getClasses();
+        yield from $this->getConstants();
+    }
+}

--- a/src/Identifiers.php
+++ b/src/Identifiers.php
@@ -7,10 +7,18 @@ namespace pxlrbt\PhpScoper\PrefixRemover;
  */
 class Identifiers implements IdentifiersInterface
 {
+    /** @var iterable<string> */
     protected $functions;
+    /** @var iterable<string> */
     protected $classes;
+    /** @var iterable<string> */
     protected $constants;
 
+    /**
+     * @param iterable<string> $functions
+     * @param iterable<string> $classes
+     * @param iterable<string> $constants
+     */
     public function __construct(
         iterable $functions,
         iterable $classes,

--- a/src/IdentifiersInterface.php
+++ b/src/IdentifiersInterface.php
@@ -11,28 +11,28 @@ interface IdentifiersInterface
     /**
      * Retrieves a list of function identifiers.
      *
-     * @return iterable A list of function FQNs.
+     * @return iterable<string> A list of function FQNs.
      */
     public function getFunctions(): iterable;
 
     /**
      * Retrieves a list of class identifiers.
      *
-     * @return iterable A list of class FQNs. This includes classes, interfaces, and traits.
+     * @return iterable<string> A list of class FQNs. This includes classes, interfaces, and traits.
      */
     public function getClasses(): iterable;
 
     /**
      * Retrieves a list of constant identifiers.
      *
-     * @return iterable A list of constant FQNs.
+     * @return iterable<string> A list of constant FQNs.
      */
     public function getConstants(): iterable;
 
     /**
      * Retrieves a list of all identifiers.
      *
-     * @return iterable A list of identifiers for functions, classes, and constants together.
+     * @return iterable<string> A list of identifiers for functions, classes, and constants together.
      */
     public function getAll(): iterable;
 }

--- a/src/IdentifiersInterface.php
+++ b/src/IdentifiersInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace pxlrbt\PhpScoper\PrefixRemover;
+
+/**
+ * A collection of PHP identifiers of different types.
+ */
+interface IdentifiersInterface
+{
+
+    /**
+     * Retrieves a list of function identifiers.
+     *
+     * @return iterable A list of function FQNs.
+     */
+    public function getFunctions(): iterable;
+
+    /**
+     * Retrieves a list of class identifiers.
+     *
+     * @return iterable A list of class FQNs. This includes classes, interfaces, and traits.
+     */
+    public function getClasses(): iterable;
+
+    /**
+     * Retrieves a list of constant identifiers.
+     *
+     * @return iterable A list of constant FQNs.
+     */
+    public function getConstants(): iterable;
+
+    /**
+     * Retrieves a list of all identifiers.
+     *
+     * @return iterable A list of identifiers for functions, classes, and constants together.
+     */
+    public function getAll(): iterable;
+}


### PR DESCRIPTION
- Identifiers are separated into 3 types: classes (classes, interfaces, and traits), functions, and constants. This is in line with what [`Reflector`][] expects.
- `IdentifierExtractor` now returns a new `IdentifiersInterface`, which separates identifiers by type, and also allows retrieving all identifiers in a flat list.
- `IdentifierExtractor` retrieves an `IdentifierInterface` per file, and uses a `CompositeIdentifiers` to merge the identifier collections from all files together.

[`Reflector`]: https://github.com/humbug/php-scoper/blob/117ed8c3cf278d2fba5ca5115e74bb88f984916d/src/Reflector.php