### PR TITLE
Allow user to provide lexer for PhpParser

### DIFF
--- a/src/IdentifierExtractor.php
+++ b/src/IdentifierExtractor.php
@@ -3,19 +3,22 @@
 namespace pxlrbt\PhpScoper\PrefixRemover;
 
 use PhpParser\ParserFactory;
+use PhpParser\Lexer;
 
 class IdentifierExtractor
 {
-    public function __construct($statements = null, $lexer = null)
+    protected ?Lexer $lexer = null;
+    protected array $stubFiles = [];
+    protected array $extractStatements = [];
+    
+    public function __construct($statements = null)
     {
-        $this->stubFiles = [];
         $this->extractStatements = $statements ?? [
             "Stmt_Class",
             "Stmt_Interface",
             "Stmt_Trait",
             "Stmt_Function"
         ];
-        $this->lexer = $lexer;
     }
 
     public function addStub($file)

--- a/src/IdentifierExtractor.php
+++ b/src/IdentifierExtractor.php
@@ -6,7 +6,7 @@ use PhpParser\ParserFactory;
 
 class IdentifierExtractor
 {
-    public function __construct($statements = null)
+    public function __construct($statements = null, $lexer = null)
     {
         $this->stubFiles = [];
         $this->extractStatements = $statements ?? [
@@ -15,11 +15,18 @@ class IdentifierExtractor
             "Stmt_Trait",
             "Stmt_Function"
         ];
+        $this->lexer = $lexer;
     }
 
     public function addStub($file)
     {
         $this->stubFiles[] = $file;
+        return $this;
+    }
+
+    public function setLexer($lexer)
+    {
+        $this->lexer = $lexer;
         return $this;
     }
 
@@ -37,7 +44,7 @@ class IdentifierExtractor
 
     protected function generateAst($code)
     {
-        $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7, $this->lexer);
         return $parser->parse($code);
     }
 


### PR DESCRIPTION
WordPress has a function named `readonly` which appears to be scheduled for a rename in v5.9 (https://core.trac.wordpress.org/ticket/53858).

Readonly is is a reserved keyword in PHP 8.1, so unfortunately in the meantime PhpParser is throwing a fatal error:

```
PHP Fatal error:  Uncaught PhpParser\Error: Syntax error, unexpected T_READONLY, expecting T_STRING or '(' on line 98413 in /Users/ssnspenthe/Code/php-scoper-prefix-remover/vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:318
```

The fix is to either not use the default `Emulative` lexer or to specifically set a target PHP version on the `Emulative` lexer (https://github.com/nikic/PHP-Parser/issues/799#issuecomment-885599753).

This PR gives the user the option of providing a lexer for PhpParser to use so problems like this can be avoided in the future.

It still works as before:

```php
use pxlrbt\PhpScoper\PrefixRemover\IdentifierExtractor;

$identifiers = (new IdentifierExtractor())
    ->addStub('vendor/php-stubs/wordpress-stubs/wordpress-stubs.php')
    ->extract();
```

But now we have the option to override the lexer:

```php
use pxlrbt\PhpScoper\PrefixRemover\IdentifierExtractor;
use PhpParser\Lexer\Emulative;

$identifiers = (new IdentifierExtractor())
    ->addStub('vendor/php-stubs/wordpress-stubs/wordpress-stubs.php')
    ->setLexer(new Emulative(['phpVersion' => '8.0']))
    ->extract();
```